### PR TITLE
Feat: social hover

### DIFF
--- a/src/components/home/Profile.tsx
+++ b/src/components/home/Profile.tsx
@@ -42,6 +42,7 @@ export default function Profile({ author, social, features, researchInterests }:
     const [showEmail, setShowEmail] = useState(false);
     const [isEmailPinned, setIsEmailPinned] = useState(false);
     const [lastClickedTooltip, setLastClickedTooltip] = useState<'email' | 'address' | null>(null);
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
     // Check local storage for user's like status
     useEffect(() => {
@@ -136,7 +137,7 @@ export default function Profile({ author, social, features, researchInterests }:
 
             {/* Contact Links */}
             <div className="flex flex-wrap justify-center gap-3 sm:gap-4 mb-6 relative px-2">
-                {socialLinks.map((link) => {
+                {socialLinks.map((link, idx) => {
                     const IconComponent = link.icon;
                     if (link.isLocation) {
                         return (
@@ -287,16 +288,33 @@ export default function Profile({ author, social, features, researchInterests }:
                         );
                     }
                     return (
-                        <a
-                            key={link.name}
-                            href={link.href}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="p-2 sm:p-2 text-neutral-600 dark:text-neutral-400 hover:text-accent transition-colors duration-200"
-                            aria-label={link.name}
-                        >
-                            <IconComponent className="h-5 w-5" />
-                        </a>
+                        <div key={link.name} className="relative">
+                            <a
+                                href={link.href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onMouseEnter={() => setHoveredIndex(idx)}
+                                onMouseLeave={() => setHoveredIndex(null)}
+                                onFocus={() => setHoveredIndex(idx)}
+                                onBlur={() => setHoveredIndex(null)}
+                                className="p-2 sm:p-2 text-neutral-600 dark:text-neutral-400 hover:text-accent transition-colors duration-200"
+                                aria-label={link.name}
+                            >
+                                <IconComponent className="h-5 w-5" />
+                            </a>
+                            <AnimatePresence>
+                                {hoveredIndex === idx && (
+                                    <motion.div
+                                        initial={{ opacity: 0, y: 10, scale: 0.9 }}
+                                        animate={{ opacity: 1, y: -8, scale: 1 }}
+                                        exit={{ opacity: 0, y: -16, scale: 0.9 }}
+                                        className="absolute top-0 left-1/2 transform -translate-x-1/2 -translate-y-full bg-neutral-800 text-white px-3 py-2 rounded-md text-xs font-medium shadow-lg whitespace-nowrap z-20"
+                                    >
+                                        {link.name}
+                                    </motion.div>
+                                )}
+                            </AnimatePresence>
+                        </div>
                     );
                 })}
             </div>

--- a/src/components/home/Profile.tsx
+++ b/src/components/home/Profile.tsx
@@ -136,7 +136,7 @@ export default function Profile({ author, social, features, researchInterests }:
             </div>
 
             {/* Contact Links */}
-            <div className="flex flex-wrap justify-center gap-3 sm:gap-4 mb-6 relative px-2">
+            <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 mb-6 relative px-2">
                 {socialLinks.map((link, idx) => {
                     const IconComponent = link.icon;
                     if (link.isLocation) {
@@ -153,7 +153,7 @@ export default function Profile({ author, social, features, researchInterests }:
                                         setShowAddress(!isAddressPinned);
                                         setLastClickedTooltip('address');
                                     }}
-                                    className={`p-2 sm:p-2 transition-colors duration-200 ${isAddressPinned
+                                    className={`inline-flex items-center justify-center p-2 sm:p-2 transition-colors duration-200 ${isAddressPinned
                                         ? 'text-accent'
                                         : 'text-neutral-600 dark:text-neutral-400 hover:text-accent'
                                         }`}
@@ -230,7 +230,7 @@ export default function Profile({ author, social, features, researchInterests }:
                                         setShowEmail(!isEmailPinned);
                                         setLastClickedTooltip('email');
                                     }}
-                                    className={`p-2 sm:p-2 transition-colors duration-200 ${isEmailPinned
+                                    className={`inline-flex items-center justify-center p-2 sm:p-2 transition-colors duration-200 ${isEmailPinned
                                         ? 'text-accent'
                                         : 'text-neutral-600 dark:text-neutral-400 hover:text-accent'
                                         }`}
@@ -297,7 +297,7 @@ export default function Profile({ author, social, features, researchInterests }:
                                 onMouseLeave={() => setHoveredIndex(null)}
                                 onFocus={() => setHoveredIndex(idx)}
                                 onBlur={() => setHoveredIndex(null)}
-                                className="p-2 sm:p-2 text-neutral-600 dark:text-neutral-400 hover:text-accent transition-colors duration-200"
+                                className="inline-flex items-center justify-center p-2 sm:p-2 text-neutral-600 dark:text-neutral-400 hover:text-accent transition-colors duration-200"
                                 aria-label={link.name}
                             >
                                 <IconComponent className="h-5 w-5" />


### PR DESCRIPTION
While working on the Profile component, I noticed a small detail that could be polished to improve the user experience.

This PR introduces a improvement to the social links:

- Added tooltips that display the social link name on hover and focus. This provides better context for screen readers and keyboard users. Fixed the vertical alignment of the icons. I also ensured the icons are perfectly centered within their buttons.

Previously the social links except email and location did not display anything on hover. 