### PR TITLE
Auto-generate “Last updated” date

### DIFF
--- a/content/config.toml
+++ b/content/config.toml
@@ -2,7 +2,6 @@
 title = "Jiale Liu"
 description = "PhD student at the University of Example."
 favicon = "/favicon.svg"
-last_updated = "November 18, 2025"
 
 [author]
 name = "Jiale Liu"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -107,7 +107,13 @@ export default function RootLayout({
           <main className="min-h-screen pt-16 lg:pt-20">
             {children}
           </main>
-          <Footer lastUpdated={config.site.last_updated} />
+          <Footer
+            lastUpdated={new Date().toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          />
         </ThemeProvider>
       </body>
     </html>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,7 +7,6 @@ export interface SiteConfig {
         title: string;
         description: string;
         favicon: string;
-        last_updated?: string;
     };
     author: {
         name: string;


### PR DESCRIPTION
Automatically generate the “Last updated” date instead of relying on a manually maintained string.

Keeps the existing human-readable date format (e.g., “January 11, 2026”)